### PR TITLE
feat(farmview): add eggs and kegs to the Greenhouse

### DIFF
--- a/utils/lookups.js
+++ b/utils/lookups.js
@@ -887,7 +887,7 @@ export const MAP_SIZES = {
   'generated/Trailer-5-5': { x: 25, y: 25 },
   'generated/Trailer-6-5': { x: 25, y: 25 },
   'generated/Trailer-9-7': { x: 25, y: 25 },
-  Greenhouse: { x: 19, y: 23 },
+  Greenhouse: { x: 20, y: 24 },
   HaleyHouse: { x: 25, y: 25 },
   HarveyRoom: { x: 24, y: 13 },
   Hospital: { x: 24, y: 20 },

--- a/utils/stardew.js
+++ b/utils/stardew.js
@@ -266,8 +266,14 @@ export function findHarvestInLocations(gameState, names = []) {
     const tappers = filterObjectsByName(location, 'Tapper');
     const preservesJars = filterObjectsByName(location, 'Preserves Jar');
     const beeHouses = filterObjectsByName(location, 'Bee House');
-    const eggs = findInBuildings(location, 'Coop', ['Egg']);
-    const kegs = findInBuildings(location, 'Barn', ['Keg']);
+    const eggs = [
+      ...filterObjectsByName(location, 'Egg'),
+      ...findInBuildings(location, 'Coop', ['Egg']),
+    ];
+    const kegs = [
+      ...findInBuildings(location, 'Barn', ['Keg']),
+      ...filterObjectsByName(location, 'Keg'),
+    ];
     const trees = location.terrainFeatures.item
       .filter(o => o.value.TerrainFeature['@_xsi:type'] === 'FruitTree')
       .map(o => ({


### PR DESCRIPTION
Search for eggs and kegs both in the location and inside of buildings in the location. This will hit
both the Coop in the farm, but will also work if you render the Coop separately. Also; will find Kegs anywhere in the location (for example when showing the Greenhouse)